### PR TITLE
Switch Docker Hub repository to `heroku/buildpack-procfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Changed repository name from `heroku/procfile-cnb` to `heroku/buildpacks-procfile`. ([#216](https://github.com/heroku/buildpacks-procfile/pull/216))
+### Changed
+
+- Switched Docker Hub repository from `docker.io/heroku/procfile-cnb` to `docker.io/heroku/buildpack-procfile`. ([#219](https://github.com/heroku/buildpacks-procfile/pull/219))
+- Renamed GitHub repository from `heroku/procfile-cnb` to `heroku/buildpacks-procfile`. ([#216](https://github.com/heroku/buildpacks-procfile/pull/216))
 
 ## [3.0.0] - 2024-02-28
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -23,4 +23,4 @@ os = "linux"
 arch = "amd64"
 
 [metadata.release]
-image = { repository = "docker.io/heroku/procfile-cnb" }
+image = { repository = "docker.io/heroku/buildpack-procfile" }


### PR DESCRIPTION
To match the naming used by our other CNBs, and the new GitHub repo name for this CNB.

The change to the repo metadata here will cause new versions to be published to the new repo instead.

The existing tags on the old repo have been [copied over](https://github.com/heroku/buildpacks-procfile/actions/runs/8260980640/job/22597453080#step:5:1) already using:
`crane copy --all-tags --jobs 1 docker.io/heroku/procfile-cnb docker.io/heroku/buildpack-procfile`

(the `--jobs 1` was to ensure the tags appear in the correct order when sorted by push date)

See:
https://hub.docker.com/r/heroku/procfile-cnb/tags
https://hub.docker.com/r/heroku/buildpack-procfile/tags

Once this PR has merged, I'll update the index to reference the new repo for old versions too:
https://github.com/buildpacks/registry-index/blob/main/pr/oc/heroku_procfile

GUS-W-15241542.