### PR TITLE
Add arm64 target

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,5 +22,9 @@ id = "*"
 os = "linux"
 arch = "amd64"
 
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-procfile" }


### PR DESCRIPTION
This PR simply adds a ARM64 linux target to `buildpack.toml`, so the buildpack can be compiled and packaged with `libcnb.rs` and `pack`