### PR TITLE
`arm64` and multi-arch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for `arm64` and multi-arch images.
+
 ## [3.0.1] - 2024-03-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Support for `arm64` and multi-arch images.
+- Support for `arm64` and multi-arch images. ([#225](https://github.com/heroku/buildpacks-procfile/pull/225))
 
 ## [3.0.1] - 2024-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Support for `arm64` and multi-arch images. ([#225](https://github.com/heroku/buildpacks-procfile/pull/225))
 
 ## [3.0.1] - 2024-03-13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ unused_crate_dependencies = "warn"
 
 [lints.clippy]
 panic_in_result_fn = "warn"
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 
 [dependencies]


### PR DESCRIPTION
There's really nothing to do here except add a changelog entry; the `buildpack.toml` already has both targets. The next release will be published as multi-arch, since https://github.com/heroku/languages-github-actions/pull/194 is merged.