### PR TITLE
Remove `[[stacks]]` table workaround from `buildpack.toml`

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,13 +11,6 @@ keywords = ["procfile", "processes", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# [[stacks]] is deprecated in Buildpack API 0.10, but is (unintentionally?)
-# required by `pack buildpack package`. The [[stacks]] table should be
-# removed when the issue (https://github.com/buildpacks/pack/issues/2047) is
-# resolved.
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
Since we're now using a Pack CLI version in our CNB release automation that contains the fix for:
https://github.com/buildpacks/pack/issues/2047