### PR TITLE
Add test coverage of compound bash commands

### DIFF
--- a/tests/fixtures/complex_command_procfile/Procfile
+++ b/tests/fixtures/complex_command_procfile/Procfile
@@ -1,0 +1,2 @@
+# Tests use of compound bash commands, both quote styles, nested quoting and variable interpolation.
+web: echo 'this is the "web" process!' && echo "\"PORT\" is set to: '${PORT}'"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -110,6 +110,27 @@ fn test_multiple_non_web_procfile() {
 
 #[test]
 #[ignore = "integration test"]
+// Tests use of compound bash commands, both quote styles, nested quoting and variable interpolation.
+fn test_complex_command_procfile() {
+    TestRunner::default().build(
+        BuildConfig::new(
+            "heroku/builder:22",
+            "tests/fixtures/complex_command_procfile",
+        ),
+        |context| {
+            context.start_container(ContainerConfig::new().env("PORT", "12345"), |container| {
+                let log_output = container.logs_wait();
+                assert_eq!(
+                    log_output.stdout,
+                    "this is the \"web\" process!\n\"PORT\" is set to: '12345'\n"
+                );
+            });
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 // Tests a Procfile that happens to not be valid YAML, but is still valid according
 // to the supported Procfile syntax.
 fn test_not_yaml_procfile() {


### PR DESCRIPTION
The `Procfile` format supports specifying compound bash commands like:

```
web: foo && bar
```

This buildpack currently supports these, however, there is no integration test coverage of them.

Having coverage is important, since some of the approaches for implementing the `bash -c` wrapping don't support usage of compound commands, as seen in:
https://github.com/heroku/buildpacks-procfile/pull/150#discussion_r1180473346

This test case was extracted from #150 (which itself was superseded).

As such I've added a new integration test for this, which also tests quoting (in case a future buildpack implementation starts trying to parse/escape the commands) and variable interpolation.