### PR TITLE
Stop grouping libcnb Dependabot PRs separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,6 @@ updates:
       - "rust"
       - "skip changelog"
     groups:
-      # Note: The group order matters, since updates are assigned to the first matching group.
-      libcnb:
-        patterns:
-          - "libcnb*"
-          - "libherokubuildpack"
       rust-dependencies:
         update-types:
           - "minor"


### PR DESCRIPTION
To work around this Dependabot bug:
https://github.com/dependabot/dependabot-core/issues/11093